### PR TITLE
Refactor/Bug Fix on admin/shelters index page

### DIFF
--- a/app/controllers/admin_shelters_controller.rb
+++ b/app/controllers/admin_shelters_controller.rb
@@ -2,9 +2,25 @@ class AdminSheltersController < ApplicationController
   def index
     @shelters = Shelter.reverse_order_by_name
     @applications = Application.pending_apps
+    @pending_shelters = no_duplicate_pets
   end
 
   def show
     @shelter = Shelter.find(params[:id])
   end
+
+
+  private
+    def no_duplicate_pets
+      shelters = Shelter.reverse_order_by_name
+      applications = Application.pending_apps
+      pending_shelters = []
+      applications.each do |app|
+        app.pets.each do |pet|
+          pending_shelters << pet.shelter
+        end
+      end
+      pending_shelters.uniq
+      # require "pry"; binding.pry
+    end
 end

--- a/app/views/admin_shelters/index.html.erb
+++ b/app/views/admin_shelters/index.html.erb
@@ -14,9 +14,8 @@
 <section id="pending_application">
 <h2>Shelters with Pending Applications:</h2>
 
-<% @applications.pending_apps.each do |application| %>
-    <% application.pets.each do |pet| %>
-      <%= pet.shelter.name %><br>
-    <% end %>
+<% @pending_shelters.each do |pending_shelter| %>
+  <%= pending_shelter.name %>
 <% end %>
+
 </section>


### PR DESCRIPTION
In this PR:
- located the cause of the bug that was causing the Shelters With Pending Apps section of the /admin/shelters index page to display duplicate shelters
- this bug was fixed by abstracting the iteration to get shelter names with pending apps back into the admin_index controller
- created a private method to do the iteration and return only unique shelter names
- used private method to create a global variable containing only unique shelters with pending apps
- iterated through this collection in the view, instead of the nested iteration we had originally 